### PR TITLE
Set dependency to ATs to optional

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,5 @@
 PalladioPipeline {
     deployUpdatesite 'releng/org.palladiosimulator.examples.package.updatesite/target/repository'
 	skipQualityMetrics true
+    skipDeploy false
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,4 @@
 PalladioPipeline {
     deployUpdatesite 'releng/org.palladiosimulator.examples.package.updatesite/target/repository'
 	skipQualityMetrics true
-    skipDeploy false
 }

--- a/bundles/org.palladiosimulator.examples.package/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.examples.package/META-INF/MANIFEST.MF
@@ -4,6 +4,6 @@ Bundle-Name: Examples - New Project Catalog
 Bundle-SymbolicName: org.palladiosimulator.examples.package;singleton:=true
 Bundle-Version: 4.3.0.qualifier
 Bundle-Vendor: palladiosimulator.org
-Require-Bundle: org.palladiosimulator.architecturaltemplates
+Require-Bundle: org.palladiosimulator.architecturaltemplates;resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
Set the dependency of the bundle to the AT bundle to optional, as it is only required for registering with trhe extension point. In case the model is resolved programmatically, ATs are not necessarily available. As the feature still requires ATs to be present, we do not risk anything by setting the bundle dependency to optional.